### PR TITLE
report error.stack to user

### DIFF
--- a/js/demo.js
+++ b/js/demo.js
@@ -28,7 +28,7 @@ require(["../src/json.human"], function (JsonHuman) {
         try {
             json = JSON.parse(editor.getValue());
         } catch (error) {
-            alert("Error parsing json");
+            alert("Error parsing json:\n" + error.stack);
             return;
         }
 


### PR DESCRIPTION
Hi, this is a neat idea!

Even though this is only a demo, it might still be a good idea to try reporting details to the user.

We know that JSON data can easily become invalid by a missed trailing comma, single-quote instead of double-quotes, etc.

While the reporting is not very detailed in such cases it might still be useful to the user to see something like this:

```
Error parsing json:
SyntaxError: Unexpected token '
  at Object.parse (native)
  at HTMLButtonElement.doConvert (http://marianoguerra.github.io/json.human.js/js/demo.js:29:25)
```

when I make a change like that

```
{
  'name': "json.human",
  "description": "Convert JSON to human readable HTML",
  ...
```
