### PR TITLE
Adds bower compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,14 @@ you can see js/demo.js in this repo for an example or use it live at the `projec
     var node = JsonHuman.format(input);
     output.appendChild(node);
 
+
+To install it, if you're using `Bower <https://github.com/bower/bower>`_ you can just run :
+
+::
+
+    bower install json-human --save
+
+
 Alternatives
 ------------
 

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,7 @@
+{
+    "name": "json-human",
+    "version": "1.0.0",
+    "main": "./src/json.human.js",
+    "dependencies": {
+    }
+}


### PR DESCRIPTION
Json.human.js does not support [Bower](http://bower.io/), with this pull requests everyone will be able to add it to their projects just by doing `bower install json-human`.

Once this is merged, the following needs to be ran : 

`bower register json-human https://github.com/marianoguerra/json.human.js.git`
