### PR TITLE
Enahcements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ you can see js/demo.js in this repo for an example or use it live at the
 Additional options parameter can be supplied
 
 ::
+
     var input = {
           "url" : [
                 "www.google.com",

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,35 @@ you can see js/demo.js in this repo for an example or use it live at the
     output.appendChild(node);
 
 
+Additional options parameter can be supplied
+
+::
+    var input = {
+          "url" : [
+                "www.google.com",
+                "www.google.com",
+                {
+                  "x" : "x-direction",
+                  "y" : "y-direction",
+                  "url" : "www.google.com"
+                }
+          ]
+    };
+
+    var node = JsonHuman.format(input, {
+        // Show or hide Array-Indices in the output
+        showArrayIndex: true,
+
+        // Hyperlinks Option
+        // Enable <a> tag in the output html based on object keys
+        // Supports only strings and arrays
+        hyperlinks : {
+            enable : true,
+            keys: ['url'],          // Keys which will be output as links
+            target : '_blank'       // 'target' attribute of a
+        }
+    });
+
 To install it, if you're using `Bower <https://github.com/bower/bower>`_ you
 can just run::
 

--- a/css/json.human.css
+++ b/css/json.human.css
@@ -75,3 +75,19 @@ th.jh-key{
  color: #999;
  font-size: small;
 }
+
+.jh-a {
+    text-decoration: none;
+}
+
+.jh-a:hover{
+    text-decoration: underline;
+}
+
+.jh-a span.jh-type-string {
+    text-decoration: none;
+    font-weight: bold;
+    color : #268ddd;
+    font-style: normal;
+}
+

--- a/js/demo.no.requirejs.js
+++ b/js/demo.no.requirejs.js
@@ -11,7 +11,14 @@
         });
 
     function convert(input, output) {
-        var node = JsonHuman.format(input);
+        var node = JsonHuman.format(input, {
+            showArrayIndex: true,
+            hyperlinks : {
+                enable : true,
+                keys: ['url', 'main'],
+                target : '_blank'
+            }
+        });
 
         output.innerHTML = "";
         output.appendChild(node);

--- a/js/demo.no.requirejs.js
+++ b/js/demo.no.requirejs.js
@@ -12,7 +12,7 @@
 
     function convert(input, output) {
         var node = JsonHuman.format(input, {
-            showArrayIndex: true,
+            showArrayIndex: false,
             hyperlinks : {
                 enable : true,
                 keys: ['url', 'main'],


### PR DESCRIPTION
# Option to hide Array Index (Issue #5)


Pass showArrayIndex: true / false to hide or show array indices in the output
If not set, it is assumed to be true

# Option to output hyperlinks in the HTML output (Issue #4)

Create "hyperlinks" key in the options to enable this in output

hyperlinks : {
            enable : true,
            keys: ['url'],          // Keys which will be output as links
            target : '_blank'   // 'target' attribute of a
        }

# Code changes

## JS
_format will get two more params - the options object and also parentKey to set the context. This is useful when we are parsing arrays and need to know what the parent-key was. For now, useful to identify if we are parsing list of hyperlinks. Could be useful for other things in future.

validateOptions methods will be used to validate the options object passed-in. Any new validations can be inside this (ex validateHyperlinkOptions and validateArrayIndexOption)

linkNode functions is like scn. Creates a a-node(hyperlink) and appends child node to that.


## CSS 
New classes for hyperlinks

